### PR TITLE
Fixed references to `maxPoolTokens` in IPool.sol join functions. Resolves #20

### DIFF
--- a/contracts/balancer/IPool.sol
+++ b/contracts/balancer/IPool.sol
@@ -385,7 +385,7 @@ contract IPool is BToken, BMath {
     uint256 maxPoolTokens = _maxPoolTokens;
     if (maxPoolTokens > 0) {
       require(
-        badd(poolTotal, poolAmountOut) <= _maxPoolTokens,
+        badd(poolTotal, poolAmountOut) <= maxPoolTokens,
         "ERR_MAX_POOL_TOKENS"
       );
     }
@@ -442,7 +442,7 @@ contract IPool is BToken, BMath {
     uint256 maxPoolTokens = _maxPoolTokens;
     if (maxPoolTokens > 0) {
       require(
-        badd(_totalSupply, poolAmountOut) <= _maxPoolTokens,
+        badd(_totalSupply, poolAmountOut) <= maxPoolTokens,
         "ERR_MAX_POOL_TOKENS"
       );
     }
@@ -479,7 +479,7 @@ contract IPool is BToken, BMath {
     uint256 maxPoolTokens = _maxPoolTokens;
     if (maxPoolTokens > 0) {
       require(
-        badd(_totalSupply, poolAmountOut) <= _maxPoolTokens,
+        badd(_totalSupply, poolAmountOut) <= maxPoolTokens,
         "ERR_MAX_POOL_TOKENS"
       );
     }


### PR DESCRIPTION
The join pool functions in IPool.sol copied `_maxPoolTokens` locally before checking them, but erroneously still used the storage variable in the verification step.

Replaced reference to storage variable with copied variable already on the stack.