### PR TITLE
Improve code clarity in UnboundTokenSeller.sol | Resolves #18

### DIFF
--- a/contracts/UnboundTokenSeller.sol
+++ b/contracts/UnboundTokenSeller.sol
@@ -204,7 +204,7 @@ contract UnboundTokenSeller {
     // Get the actual amount paid
     uint256 amountIn = amounts[0];
     // If we did not swap the full amount, remove the UniSwap allowance.
-    if (amountIn != maxAmountIn) {
+    if (amountIn < maxAmountIn) {
       IERC20(tokenIn).safeApprove(address(_uniswapRouter), 0);
       premiumPaidToCaller = maxAmountIn - amountIn;
       // Transfer the difference between what the contract was willing to pay and
@@ -265,7 +265,7 @@ contract UnboundTokenSeller {
   
     // Get the actual amount paid
     uint256 amountOut = amounts[amounts.length - 1];
-    if (amountOut != minAmountOut) {
+    if (amountOut > minAmountOut) {
       // Transfer any tokens received beyond the minimum acceptable payment
       // to the caller as a reward.
       premiumPaidToCaller = amountOut - minAmountOut;


### PR DESCRIPTION
Implemented suggestion from @cleanunicorn to replace != with `>` and `<` in the Uniswap functions in UnboundTokenSeller.

The contract checks whether the received/paid amount in a swap was more/less than it expected in order to determine whether to pay the caller for triggering the call.  Because of the way Uniswap works, `!=` is the equivalent of `>`/`<` (because the maximums and minimums can not be exceeded), but for the sake of code clarity they should use gt/lt comparison, and there is no extra cost incurred by doing so. It may even reduce the gas used by ~3.