### PR TITLE
Replaced memory pointers with storage pointers for some functions in IPool.sol | Resolves #15

### DIFF
--- a/contracts/balancer/IPool.sol
+++ b/contracts/balancer/IPool.sol
@@ -1028,7 +1028,7 @@ contract IPool is BToken, BMath {
     view
     returns (uint256 balance)
   {
-    Record memory record = _records[token];
+    Record storage record = _records[token];
     require(record.bound, "ERR_NOT_BOUND");
     balance = record.balance;
   }


### PR DESCRIPTION
Implemented suggestion from @cleanunicorn to replace some in-memory structs with storage pointers. Tested each function to verify the cost reduction and implemented changes only where it reduced gas.

Reduced the costs of these functions by the following amounts:
- `reindexPool()` ~4k gas (in test file which uses 3 tokens)
- `reweighPool()` ~4k gas (in test file which uses 3 tokens)
- `setMinimumBalance()` ~400 gas
- `getCurrentDesiredTokens()` ~5k gas
- `flashBorrow()` ~500 gas
- `getBalance()` ~500 gas

The gas optimizations for `reindexPool` and `reweighPool` are due to the modification to `_setDesiredDenorm`