### PR TITLE
Remove `updateSellerPremiumToDefault` functions, replace with permissioned setter.

### DIFF
--- a/contracts/MarketCapSqrtController.sol
+++ b/contracts/MarketCapSqrtController.sol
@@ -292,27 +292,10 @@ contract MarketCapSqrtController is MarketCapSortedTokenCategories {
   }
 
   /**
-   * @dev Update the premium rate on `sellerAddress` with the current
-   * default rate.
+   * @dev Set the premium rate on `sellerAddress` to the given rate.
    */
-  function updateSellerPremiumToDefault(
-    address sellerAddress
-  ) external {
-    UnboundTokenSeller(sellerAddress).setPremiumPercent(defaultSellerPremium);
-  }
-
-  /**
-   * @dev Update the premium rate on each unbound token seller in
-   * `sellerAddresses` with the current default rate.
-   */
-  function updateSellerPremiumToDefault(
-    address[] calldata sellerAddresses
-  ) external {
-    for (uint256 i = 0; i < sellerAddresses.length; i++) {
-      UnboundTokenSeller(
-        sellerAddresses[i]
-      ).setPremiumPercent(defaultSellerPremium);
-    }
+  function updateSellerPremium(address tokenSeller, uint8 premiumPercent) external _owner_ {
+    UnboundTokenSeller(tokenSeller).setPremiumPercent(premiumPercent);
   }
 
   /**


### PR DESCRIPTION
Implement suggested improvement from @cleanunicorn

## Changes
Removed both functions for `updateSellerPremiumToDefault`, replaced with:

```
function updateSellerPremium(address tokenSeller, uint8 premiumPercent) external _owner_ {
  UnboundTokenSeller(tokenSeller).setPremiumPercent(premiumPercent);
}
```

**Note:** The default premium is kept, as that will still be used when deploying new seller contracts.