### PR TITLE
Merged IndexPoolMeta and PoolUpdateRecord structs and fixed references to them. Resolves #5 #7 #10 #13

### DIFF
--- a/contracts/MarketCapSqrtController.sol
+++ b/contracts/MarketCapSqrtController.sol
@@ -123,6 +123,13 @@ contract MarketCapSqrtController is MarketCapSortedTokenCategories {
    * If `++index % REWEIGHS_BEFORE_REINDEX + 1` is 0, the pool will
    * re-index, otherwise it will reweigh.
    *
+   * The struct fields are assigned their respective integer sizes so
+   * that solc can pack the entire struct into a single storage slot.
+   * `reweighIndex` is intended to overflow, `categoryID` will never
+   * reach 2**16, `indexSize` is capped at 10 and it is unlikely that
+   * this protocol will be in use in the year 292277026596 (unix time
+   * for 2**64 - 1).
+   *
    * @param initialized Whether the pool has been initialized with the
    * starting balances.
    * @param categoryID Category identifier for the pool.


### PR DESCRIPTION
Made all of these changes as a single PR since they are related to the use of the structs which were modified.

Merged IndexPoolMeta and PoolUpdateRecord into a single struct. (resolves #13)

Fixed erroneous typecast to uint8 for `categoryID` in `prepareIndexPool`. (resolves #5)

Replaced `_havePool` function with modifier of the same name. Replaced references in all functions that used it except for `reweighPool`, which already has access to the struct. (resolves #7)

Set pool's last reweigh timestamp in `finishPreparedIndexPool` (resolves #10)

Modified order of execution to apply storage updates to meta prior to calling reweigh and reindex. This is unlikely to be an issue due to the fact that the pool is always an approved implementation, but there's no efficiency impact so to stay on the safe side I switched the order.

Added explanation of IndexPoolMeta struct field sizes. As mentioned in a suggestion from @cleanunicorn, it is worthwhile to explain why the struct fields have the sizes they do.