### PR TITLE
Fixes #19

### DIFF
--- a/contracts/balancer/IPool.sol
+++ b/contracts/balancer/IPool.sol
@@ -1045,9 +1045,9 @@ contract IPool is BToken, BMath {
   }
 
   /**
-   * @dev Finds the first token which is initialized and
-   * returns the address of that token and the extrapolated
-   * value of the pool in that token.
+   * @dev Finds the first token which is both initialized and has a
+   * desired weight above 0, then returns the address of that token
+   * and the extrapolated value of the pool in terms of that token.
    *
    * The value is extrapolated by multiplying the token's
    * balance by the reciprocal of its normalized weight.
@@ -1064,12 +1064,14 @@ contract IPool is BToken, BMath {
     uint256 len = _tokens.length;
     for (uint256 i = 0; i < len; i++) {
       token = _tokens[i];
-      if (!_records[token].ready) continue;
-      extrapolatedValue = bmul(
-        _records[token].balance,
-        bdiv(_totalWeight, _records[token].denorm)
-      );
-      break;
+      Record storage record = _records[token];
+      if (record.ready && record.desiredDenorm > 0) {
+        extrapolatedValue = bmul(
+          record.balance,
+          bdiv(_totalWeight, record.denorm)
+        );
+        break;
+      }
     }
     require(extrapolatedValue > 0, "ERR_NONE_READY");
     return (token, extrapolatedValue);


### PR DESCRIPTION
The `extrapolatePoolValueFromToken` function returns the first token with `record.ready == true`, but it should return the first token with `record.ready == true && record.desiredDenorm > 0`

[Ref](https://github.com/indexed-finance/indexed-core/blob/37506434cc6d223746f01104f65039886dc9b704/contracts/balancer/IPool.sol#L995)

This PR updates the function.