### PR TITLE
Enable delegation of comp-like tokens

### DIFF
--- a/contracts/MarketCapSqrtController.sol
+++ b/contracts/MarketCapSqrtController.sol
@@ -377,6 +377,22 @@ contract MarketCapSqrtController is MarketCapSortedTokenCategories {
     pool.setMinimumBalance(tokenAddress, minimumBalance);
   }
 
+  /**
+   * @dev Delegates a comp-like governance token from an index pool
+   * to a provided address.
+   */
+  function delegateCompLikeTokenFromPool(
+    address pool,
+    address token,
+    address delegatee
+  )
+    external
+    onlyOwner
+    _havePool(pool)
+  {
+    IIndexPool(pool).delegateCompLikeToken(token, delegatee);
+  }
+
 /* ==========  Pool Rebalance Actions  ========== */
 
   /**

--- a/contracts/balancer/BConst.sol
+++ b/contracts/balancer/BConst.sol
@@ -13,7 +13,7 @@ Subject to the GPL-3.0 license
 
 
 contract BConst {
-  uint256 public constant VERSION_NUMBER = 0;
+  uint256 public constant VERSION_NUMBER = 1;
 
 /* ---  Weight Updates  --- */
 

--- a/contracts/balancer/IndexPool.sol
+++ b/contracts/balancer/IndexPool.sol
@@ -10,6 +10,7 @@ import "./BMath.sol";
 import "../interfaces/IFlashLoanRecipient.sol";
 import "../interfaces/IIndexPool.sol";
 
+
 /************************************************************************************************
 Originally from https://github.com/balancer-labs/balancer-core/blob/master/contracts/BPool.sol
 
@@ -239,8 +240,7 @@ contract IndexPool is BToken, BMath, IIndexPool {
    * Note: Swap fee must be between 0.0001% and 10%
    */
   function setSwapFee(uint256 swapFee) external override _control_ {
-    require(swapFee >= MIN_FEE, "ERR_MIN_FEE");
-    require(swapFee <= MAX_FEE, "ERR_MAX_FEE");
+    require(swapFee >= MIN_FEE && swapFee <= MAX_FEE, "ERR_INVALID_FEE");
     _swapFee = swapFee;
     emit LOG_SWAP_FEE_UPDATED(swapFee);
   }
@@ -266,9 +266,8 @@ contract IndexPool is BToken, BMath, IIndexPool {
     _lock_
     _control_
   {
-    uint256 len = tokens.length;
-    require(desiredDenorms.length == len, "ERR_ARR_LEN");
-    for (uint256 i = 0; i < len; i++)
+    require(desiredDenorms.length == tokens.length, "ERR_ARR_LEN");
+    for (uint256 i = 0; i < tokens.length; i++)
       _setDesiredDenorm(tokens[i], desiredDenorms[i]);
   }
 
@@ -290,9 +289,8 @@ contract IndexPool is BToken, BMath, IIndexPool {
     _lock_
     _control_
   {
-    uint256 len = tokens.length;
     require(
-      desiredDenorms.length == len && minimumBalances.length == len,
+      desiredDenorms.length == tokens.length && minimumBalances.length == tokens.length,
       "ERR_ARR_LEN"
     );
     // This size may not be the same as the input size, as it is possible
@@ -302,10 +300,10 @@ contract IndexPool is BToken, BMath, IIndexPool {
     bool[] memory receivedIndices = new bool[](tLen);
     // We need to read token records in two separate loops, so
     // write them to memory to avoid duplicate storage reads.
-    Record[] memory records = new Record[](len);
+    Record[] memory records = new Record[](tokens.length);
     // Read all the records from storage and mark which of the existing tokens
     // were represented in the reindex call.
-    for (uint256 i = 0; i < len; i++) {
+    for (uint256 i = 0; i < tokens.length; i++) {
       records[i] = _records[tokens[i]];
       if (records[i].bound) receivedIndices[records[i].index] = true;
     }
@@ -315,7 +313,7 @@ contract IndexPool is BToken, BMath, IIndexPool {
         _setDesiredDenorm(_tokens[i], 0);
       }
     }
-    for (uint256 i = 0; i < len; i++) {
+    for (uint256 i = 0; i < tokens.length; i++) {
       address token = tokens[i];
       // If an input weight is less than the minimum weight, use that instead.
       uint96 denorm = desiredDenorms[i];

--- a/contracts/balancer/IndexPool.sol
+++ b/contracts/balancer/IndexPool.sol
@@ -9,6 +9,7 @@ import "./BMath.sol";
 /* ========== Internal Interfaces ========== */
 import "../interfaces/IFlashLoanRecipient.sol";
 import "../interfaces/IIndexPool.sol";
+import "../interfaces/ICompLikeToken.sol";
 
 
 /************************************************************************************************
@@ -243,6 +244,18 @@ contract IndexPool is BToken, BMath, IIndexPool {
     require(swapFee >= MIN_FEE && swapFee <= MAX_FEE, "ERR_INVALID_FEE");
     _swapFee = swapFee;
     emit LOG_SWAP_FEE_UPDATED(swapFee);
+  }
+
+  /**
+   * @dev Delegate a comp-like governance token to an address
+   * specified by the controller.
+   */
+  function delegateCompLikeToken(address token,address delegatee)
+    external
+    override
+    _control_
+  {
+    ICompLikeToken(token).delegate(delegatee);
   }
 
 /* ==========  Token Management Actions  ========== */

--- a/contracts/balancer/IndexPool.sol
+++ b/contracts/balancer/IndexPool.sol
@@ -234,8 +234,6 @@ contract IndexPool is BToken, BMath, IIndexPool {
     emit LOG_MAX_TOKENS_UPDATED(maxPoolTokens);
   }
 
-/* ==========  Configuration Actions  ========== */
-
   /**
    * @dev Set the swap fee.
    * Note: Swap fee must be between 0.0001% and 10%

--- a/contracts/interfaces/ICompLikeToken.sol
+++ b/contracts/interfaces/ICompLikeToken.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+
+
+interface ICompLikeToken {
+  function delegate(address delegatee) external;
+}

--- a/contracts/interfaces/IIndexPool.sol
+++ b/contracts/interfaces/IIndexPool.sol
@@ -84,6 +84,8 @@ interface IIndexPool {
 
   function setSwapFee(uint256 swapFee) external;
 
+  function delegateCompLikeToken(address token, address delegatee) external;
+
   function reweighTokens(
     address[] calldata tokens,
     uint96[] calldata desiredDenorms

--- a/contracts/interfaces/IMarketCapSqrtController.sol
+++ b/contracts/interfaces/IMarketCapSqrtController.sol
@@ -49,7 +49,7 @@ interface IMarketCapSqrtController {
 
   function computeAverageMarketCap(address token) external view returns (uint144);
 
-  function computeAverageMarketCaps(address[] memory tokens) external view returns (uint144[] memory);
+  function computeAverageMarketCaps(address[] calldata tokens) external view returns (uint144[] memory);
 
   function hasCategory(uint256 categoryID) external view returns (bool);
 

--- a/contracts/mocks/MockERC20.sol
+++ b/contracts/mocks/MockERC20.sol
@@ -5,6 +5,8 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 
 contract MockERC20 is ERC20 {
+  mapping(address => address) public delegateeByAddress;
+
   constructor(string memory name, string memory symbol) public ERC20(name, symbol) {}
 
   // Mocks WETH deposit fn
@@ -14,5 +16,9 @@ contract MockERC20 is ERC20 {
 
   function getFreeTokens(address to, uint256 amount) public {
     _mint(to, amount);
+  }
+
+  function delegate(address delegatee) external {
+    delegateeByAddress[msg.sender] = delegatee;
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,15 +44,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/indexed-finance/index-fund.git"
+    "url": "git+https://github.com/indexed-finance/indexed-core.git"
   },
   "keywords": [],
   "author": "",
   "license": "GPL-3.0-or-later",
   "bugs": {
-    "url": "https://github.com/indexed-finance/index-fund/issues"
+    "url": "https://github.com/indexed-finance/indexed-core/issues"
   },
-  "homepage": "https://github.com/indexed-finance/index-fund#readme",
+  "homepage": "https://github.com/indexed-finance/indexed-core#readme",
   "devDependencies": {
     "@ethersproject/providers": "^5.0.9",
     "@nomiclabs/buidler": "^1.4.3",

--- a/test/IPool/IPool.spec.js
+++ b/test/IPool/IPool.spec.js
@@ -392,11 +392,11 @@ describe('IndexPool.sol', async () => {
     });
 
     it('Reverts if swapFee < 0.0001%', async () => {
-      await verifyRevert('setSwapFee', /ERR_MIN_FEE/g, toWei('0.00000099'));
+      await verifyRevert('setSwapFee', /ERR_INVALID_FEE/g, toWei('0.00000099'));
     });
 
     it('Reverts if swapFee > 10%', async () => {
-      await verifyRevert('setSwapFee', /ERR_MAX_FEE/g, toWei(0.11));
+      await verifyRevert('setSwapFee', /ERR_INVALID_FEE/g, toWei(0.11));
     });
 
     it('Sets swap fee between min and max', async () => {

--- a/test/IPool/IPool.spec.js
+++ b/test/IPool/IPool.spec.js
@@ -1040,4 +1040,15 @@ describe('IndexPool.sol', async () => {
       expect(bal.eq(0)).to.be.true;
     });
   });
+
+  describe('delegateCompLikeToken()', async () => {
+    setupTests();
+
+    it('delegates a comp-like token to the provided address', async () => {
+      await indexPool.delegateCompLikeToken(tokens[0], tokens[1]);
+      const token = await ethers.getContractAt('MockERC20', tokens[0]);
+      const delegatee = await token.delegateeByAddress(indexPool.address);
+      expect(delegatee).to.eq(tokens[1]);
+    });
+  });
 });

--- a/test/IPool/Maximum.spec.js
+++ b/test/IPool/Maximum.spec.js
@@ -410,11 +410,11 @@ describe('IndexPool.sol', async () => {
     });
 
     it('Reverts if swapFee < 0.0001%', async () => {
-      await verifyRevert('setSwapFee', /ERR_MIN_FEE/g, toWei('0.00000099'));
+      await verifyRevert('setSwapFee', /ERR_INVALID_FEE/g, toWei('0.00000099'));
     });
 
     it('Reverts if swapFee > 10%', async () => {
-      await verifyRevert('setSwapFee', /ERR_MAX_FEE/g, toWei(0.11));
+      await verifyRevert('setSwapFee', /ERR_INVALID_FEE/g, toWei(0.11));
     });
 
     it('Sets swap fee between min and max', async () => {

--- a/test/MarketCapSqrtController.spec.js
+++ b/test/MarketCapSqrtController.spec.js
@@ -186,7 +186,7 @@ describe('MarketCapSqrtController.sol', async () => {
     setupTests();
 
     it('All functions with onlyOwner modifier revert if caller is not owner', async () => {
-      const onlyOwnerFns = ['prepareIndexPool', 'setDefaultSellerPremium', 'updateSellerPremium', 'setMaxPoolTokens', 'setSwapFee'];
+      const onlyOwnerFns = ['prepareIndexPool', 'setDefaultSellerPremium', 'updateSellerPremium', 'setMaxPoolTokens', 'setSwapFee', 'delegateCompLikeTokenFromPool'];
       for (let fn of onlyOwnerFns) {
         await verifyRejection(nonOwnerFaker, fn, /Ownable: caller is not the owner/g);
       }
@@ -453,6 +453,17 @@ describe('MarketCapSqrtController.sol', async () => {
       let actualMinimumBalance = await pool.getMinimumBalance(willBeIncluded);
       expect(actualMinimumBalance.gt(previousMinimum)).to.be.true;
       expect(+calcRelativeDiff(fromWei(expectedMinimumBalance), fromWei(actualMinimumBalance))).to.be.lte(errorDelta);
+    });
+  });
+
+  describe('delegateCompLikeTokenFromPool()', async () => {
+    setupTests({ pool: true, init: true, size: 4, ethValue: 10 });
+
+    it('Delegates a comp-like token in an index pool', async () => {
+      const {token} = sortedWrappedTokens[0];
+      const delegatee = sortedWrappedTokens[1].address;
+      await controller.delegateCompLikeTokenFromPool(pool.address, token.address, delegatee);
+      expect(await token.delegateeByAddress(pool.address)).to.eq(delegatee);
     });
   });
 });


### PR DESCRIPTION
This PR:
- Reduces the code size of IndexPool by removing some redundant code patterns (#64)
  - Replaces error messages for min/max swap fee with an invalid fee message for either.
  - Replaces stack-caching of array length in some functions with direct access.
- Enables delegation of comp-like governance tokens (#63)
  - Sets the version number of BConst to 1
  - Adds a `ICompLikeToken` interface with a single `delegate` function
  - Adds `delegateCompLikeToken` function to index pool
  - Adds `delegateCompLikeTokenFromPool` function to controller
- Fixes the repository URLs in package.json